### PR TITLE
Add correct package for the which command

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -21,7 +21,7 @@ required_packages:
   - libxslt-dev
   - python-dev
   - python-setuptools
-  - which
+  - debianutils
 
 required_wsgi_packages:
   - apache2


### PR DESCRIPTION
Hiya!

Just used your package for some delicious Ansibled Ara. Looks like the `which` command in Debian is part of the `debianutils` package and not provided just by itself.

This PR should fix the issue and allow the Ara package to install properly on Debian based OS. A poor student is unfortunately too broke for pure Red Hat products ;)

Thanks,

Laurent 