### PR TITLE
Fixing the apache_config_path on Debian.yml vars

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -31,4 +31,4 @@ apache_service: apache2
 apache_user: www-data
 apache_group: www-data
 apache_log_path: /var/log/apache2
-apache_config_path: /etc/apache/sites-available
+apache_config_path: /etc/apache2/sites-available


### PR DESCRIPTION
By fixing this variable to the correct sites-available path should not fail on Debian flavored distros.