### PR TITLE
fixed handler typo

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -13,7 +13,7 @@
 #   License for the specific language governing permissions and limitations
 #   under the License.
 
-- name: Restart apache
+- name: Restart Apache
   service:
    name: "{{ apache_service }}"
    state: "restarted"


### PR DESCRIPTION
there is a case typo for the handler name.