### PR TITLE
autocreate nginx sites-enabled and sites-available convention directories for non-maintainer version

### DIFF
--- a/tasks/nginx/embedded_proxy.yml
+++ b/tasks/nginx/embedded_proxy.yml
@@ -52,7 +52,7 @@
 - name: Enable the nginx configuration on Debian-like systems
   file:
     src: "{{ nginx_config_path }}/ara.conf"
-    dest: /etc/nginx/sites-enabled/ara.conf
+    dest: "{{ nginx_config_enabled_path}}/ara.conf"
     state: link
   when: ansible_os_family == 'Debian'
   notify:

--- a/tasks/nginx/install.yml
+++ b/tasks/nginx/install.yml
@@ -68,7 +68,8 @@
   lineinfile:
     path: /etc/nginx/nginx.conf
     regexp: '^sites-enabled'
-    line: 'include /etc/nginx/sites-enabled/*;'
+    line: '    include /etc/nginx/sites-enabled/*;'
+    insertafter: '\*\.conf;'
   when: ansible_os_family == 'Debian'
 
 - name: Ensure nginx is started and enabled

--- a/tasks/nginx/install.yml
+++ b/tasks/nginx/install.yml
@@ -50,6 +50,33 @@
     - ansible_os_family == 'RedHat'
     - epel_state is changed
 
+# When NGINX doens't come from the native debian repo sites-enabled and sites-available do not exist.
+# Recreate this convention and add it to nginx.conf.
+- name: Ensure nginx config path exists on Debian-like systems (for non-maintainer nginx package)
+  file:
+    path: "{{ nginx_config_path }}"
+    state: directory
+  when: ansible_os_family == 'Debian'
+
+- name: Ensure nginx config_enabled path exists on Debian-like systems (for non-maintainer nginx package)
+  file:
+    path: "{{ nginx_config_enabled_path }}"
+    state: directory
+  when: ansible_os_family == 'Debian'
+
+- name: Ensure nginx config path exists on Debian-like systems (for non-ubuntu nginx package)
+  lineinfile:
+    path: /etc/nginx/nginx.conf
+    regexp: '^sites-enabled'
+    line: 'include /etc/nginx/sites-enabled/*;'
+  when: ansible_os_family == 'Debian'
+
+- name: Ensure nginx is started and enabled
+  service:
+    name: nginx
+    state: started
+    enabled: yes
+
 - name: Ensure nginx is started and enabled
   service:
     name: nginx

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -40,3 +40,4 @@ apache_config_path: /etc/apache2/sites-available
 nginx_user: www-data
 nginx_group: www-data
 nginx_config_path: /etc/nginx/sites-available
+nginx_config_enabled_path: /etc/nginx/sites-enabled


### PR DESCRIPTION
I upgraded nginx to mainline on my debian 9.4 box after finding out the `proxy_cache_background_update` directive is not supported yet in the nginx build included in Debian Stretch,.

I set the variables for [geerlingguy/ansible-role-nginx](https://github.com/geerlingguy/ansible-role-nginx)
```
nginx_ppa_use: true
nginx_ppa_version: mainline 
```
and ran with it, only to find out the `sites-enabled` and `sites-available` directories are a debian convention and not an nginx convention, so these did not exist.

This PR autocreates the neccesary directories, defines another default var for /sites-enabled and injects the include into nginx.conf to make the transition transparent for the next person that tries to pull this trick.